### PR TITLE
Fix typo in login page text

### DIFF
--- a/src/components/login-content.tsx
+++ b/src/components/login-content.tsx
@@ -70,7 +70,7 @@ export default function LoginContent() {
         <div className="flex flex-col items-center text-center mb-8">
           <h2 className="font-bold mb-2">NeyimVar Sistemine Nasıl Giriş Yaparım?</h2>
           <p className="w-full text-sm lg:w-4/6">
-            Sisteme girişte kimlik doğrulama google üxerinden yapılmaktdır.
+            Sisteme girişte kimlik doğrulama Google üzerinden yapılmaktadır.
           </p>
         </div>
 


### PR DESCRIPTION
## Summary
- fix typo in LoginContent component text

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c5c482da0832499519472678c82a8