### PR TITLE
Add OpenAI backend for chatbot

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Example environment variables
+OPENAI_API_KEY=your-openai-key

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "tailwind-merge": "^3.0.1",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "openai": "^4.33.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from "next/server";
+import { Configuration, OpenAIApi } from "openai";
+
+export async function POST(req: Request) {
+  const { message } = await req.json();
+
+  if (!process.env.OPENAI_API_KEY) {
+    return NextResponse.json(
+      { error: "OpenAI API key missing" },
+      { status: 500 }
+    );
+  }
+
+  const configuration = new Configuration({
+    apiKey: process.env.OPENAI_API_KEY,
+  });
+  const openai = new OpenAIApi(configuration);
+
+  try {
+    const completion = await openai.createChatCompletion({
+      model: "gpt-3.5-turbo",
+      messages: [{ role: "user", content: message }],
+    });
+
+    const aiMessage = completion.data.choices[0]?.message?.content || "";
+    return NextResponse.json({ reply: aiMessage });
+  } catch (err) {
+    console.error("OpenAI error", err);
+    return NextResponse.json(
+      { error: "Failed to generate response" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/chatbot/page.tsx
+++ b/src/app/chatbot/page.tsx
@@ -2,27 +2,39 @@
 
 import { useState } from "react";
 
+async function sendMessage(message: string): Promise<string> {
+  try {
+    const res = await fetch("/api/chat", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ message }),
+    });
+    if (!res.ok) {
+      throw new Error("Network response was not ok");
+    }
+    const data = await res.json();
+    return data.reply as string;
+  } catch {
+    return "Bir hata oluştu.";
+  }
+}
+
 export default function ChatbotPage() {
   const [messages, setMessages] = useState<{ sender: string; text: string }[]>([]);
   const [input, setInput] = useState("");
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!input.trim()) return;
 
-    // Kullanıcının mesajını ekle
-    setMessages((prev) => [...prev, { sender: "user", text: input }]);
-
-    // Basit bir cevap oluştur (şu an sahte)
-    setTimeout(() => {
-      setMessages((prev) => [
-        ...prev,
-        { sender: "user", text: input },
-        { sender: "bot", text: "Sorunuz için teşekkür ederim. Daha fazla bilgi almak ister misiniz?" },
-      ]);
-    }, 500);
-
+    const userMessage = input;
+    setMessages((prev) => [...prev, { sender: "user", text: userMessage }]);
     setInput("");
+
+    const botReply = await sendMessage(userMessage);
+    setMessages((prev) => [...prev, { sender: "bot", text: botReply }]);
   };
 
   return (


### PR DESCRIPTION
## Summary
- add OpenAI client dependency
- create `api/chat` route that calls OpenAI
- update chatbot page to fetch from API
- provide `.env.example` with `OPENAI_API_KEY`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c5dde662c83249f08844bd3f8d9e8